### PR TITLE
chore: refactor articles test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,9 +16,6 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -31,10 +28,10 @@ export default defineConfig({
     ['list'] // Change to your desired report directory
     // Add other reporters if needed
   ],
-  
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    
+
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },
@@ -44,17 +41,19 @@ export default defineConfig({
     {
       name: 'ui-tests',
       use: { ...devices['Desktop Chrome'] },
-      testDir:'./tests/ui-tests',
+      testDir: './tests/ui-tests',
       outputDir: './tests/report/test-results/ui-tests',
+      fullyParallel: true,
     },
     /**
      * uncomment below if you want to have an PW-API project
      */
     {
       name: 'api-tests',
-      testDir:'./tests/api-tests',
+      testDir: './tests/api-tests',
       workers: 1,
       outputDir: './tests/report/test-results/api-tests',
+      fullyParallel: false,
     },
 
   ],

--- a/tests/api-tests/articles.spec.ts
+++ b/tests/api-tests/articles.spec.ts
@@ -1,135 +1,222 @@
 import { test } from '@fixtures';
 import { APIResponse, expect } from '@playwright/test';
+import { endpoints, httpStatus } from '@utils/constants';
 
 const domain = 'https://conduit-api.bondaracademy.com/';
-const articlesPath = 'api/articles';
 const articlesParam = '?limit=10&offset=0';
-const loginPath = 'api/users/login';
+
+
+let authToken: string
 
 test.describe('Feature: Articles API', () => {
-  test('GET Articles', async ({ request }) => {
-    const articlesResponse: APIResponse = await request.get(
-      `${domain}/${articlesPath}${articlesParam}`,
-    );
-    expect(articlesResponse.status()).toBe(200);
-    const articlesResponseBody = await articlesResponse.json();
-    expect(articlesResponseBody).toHaveProperty('articles');
-    expect(articlesResponseBody).toHaveProperty('articlesCount');
-    expect(articlesResponseBody.articles.length).toBeGreaterThan(0);
-    expect(articlesResponseBody.articles.length).toBeLessThanOrEqual(10);
-  });
-  test('CREATE, READ, UPDATE, DELETE Article', async ({ request }) => {
-    //GET TOKEN
-    const loginResponse = await request.post(`${domain}/${loginPath}`, {
-      data: {
-        user: {
-          email: process.env.EMAIL as string,
-          password: process.env.PASSWORD as string,
-        },
-      },
+
+    test.beforeAll(async ({ request }) => {
+        const loginResponse = await request.post(`${domain}/${endpoints.login}`, {
+            data: {
+                user: {
+                    email: process.env.EMAIL as string,
+                    password: process.env.PASSWORD as string,
+                },
+            },
+        });
+        const tokenJSON = await loginResponse.json();
+        authToken = 'Token ' + tokenJSON.user.token;
     });
-    const tokenJSON = await loginResponse.json();
-    const authToken = 'Token ' + tokenJSON.user.token;
-    //CREATE ARTICLE
-    const newArticle = {
-      article: {
-        title: 'New Article Title PW AC',
-        description: 'New Article Description  PW AC',
-        body: 'This is the body of the new article.  PW AC',
-        tagList: [],
-      },
-    };
 
-    const newArticlesResponse: APIResponse = await request.post(
-      `${domain}/${articlesPath}`,
-      {
-        data: newArticle,
-        headers: {
-          Authorization: authToken,
-        },
-      },
-    );
-    expect(newArticlesResponse.status()).toBe(201);
-    const newArticlesResponseBody = await newArticlesResponse.json();
-    const articleSlug = newArticlesResponseBody.article.slug;
-    expect(newArticlesResponseBody).toHaveProperty('article');
-    expect(newArticlesResponseBody.article.title).toBe(
-      newArticle.article.title,
-    );
-    expect(newArticlesResponseBody.article.description).toBe(
-      newArticle.article.description,
-    );
-    expect(newArticlesResponseBody.article.body).toBe(newArticle.article.body);
+    test('GET Articles', async ({ request }) => {
+        const articlesResponse: APIResponse = await request.get(
+            `${domain}/${endpoints.articles}${articlesParam}`,
+        );
+        expect(articlesResponse.status()).toBe(httpStatus.Status200_Ok);
+        const articlesResponseBody = await articlesResponse.json();
+        expect(articlesResponseBody).toHaveProperty('articles');
+        expect(articlesResponseBody).toHaveProperty('articlesCount');
+        expect(articlesResponseBody.articles.length).toBeGreaterThan(0);
+        expect(articlesResponseBody.articles.length).toBeLessThanOrEqual(10);
+    });
+    test('CREATE and DELETE Article', async ({ request }) => {
 
-    const articlesResponse: APIResponse = await request.get(
-      `${domain}/${articlesPath}${articlesParam}`,
-      {
-        headers: {
-          Authorization: authToken,
-        },
-      },
-    );
-    expect(articlesResponse.status()).toBe(200);
-    //READ
-    const articlesResponseBody = await articlesResponse.json();
-    expect(articlesResponseBody.articles[0].title).toBe(
-      newArticle.article.title,
-    );
-    expect(articlesResponseBody.articles[0].description).toBe(
-      newArticle.article.description,
-    );
-    expect(articlesResponseBody.articles[0].body).toBe(newArticle.article.body);
+        //CREATE ARTICLE
+        const newArticle = {
+            article: {
+                title: 'New Article Title PW AC',
+                description: 'New Article Description  PW AC',
+                body: 'This is the body of the new article.  PW AC',
+                tagList: [],
+            },
+        };
 
-    //UPDATE
-    const updateArticleResponse = await request.put(
-      `${domain}/${articlesPath}/${articleSlug}`,
-      {
-        data: {
-          article: {
-            title: 'Updated Article Title PW AC',
-            description: 'Updated Article Description PW AC',
-            body: 'This is the updated body of the article. PW AC',
-          },
-        },
-        headers: {
-          Authorization: authToken,
-        },
-      },
-    );
-    expect(updateArticleResponse.status()).toBe(200);
-    const updateArticleResponseJSON = await updateArticleResponse.json();
-    const articleSlugUpdated = updateArticleResponseJSON.article.slug;
-    expect(updateArticleResponseJSON.article.title).toBe(
-      'Updated Article Title PW AC',
-    );
+        const newArticlesResponse: APIResponse = await request.post(
+            `${domain}/${endpoints.articles}`,
+            {
+                data: newArticle,
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(newArticlesResponse.status()).toBe(httpStatus.Status201_Created);
+        const newArticlesResponseBody = await newArticlesResponse.json();
+        const articleSlug = newArticlesResponseBody.article.slug;
+        expect(newArticlesResponseBody).toHaveProperty('article');
+        expect(newArticlesResponseBody.article.title).toBe(
+            newArticle.article.title,
+        );
+        expect(newArticlesResponseBody.article.description).toBe(
+            newArticle.article.description,
+        );
+        expect(newArticlesResponseBody.article.body).toBe(newArticle.article.body);
 
-    //DELETE
+        const articlesResponse: APIResponse = await request.get(
+            `${domain}/${endpoints.articles}${articlesParam}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(articlesResponse.status()).toBe(httpStatus.Status200_Ok);
+        //READ
+        const articlesResponseBody = await articlesResponse.json();
+        expect(articlesResponseBody.articles[0].title).toBe(
+            newArticle.article.title,
+        );
+        expect(articlesResponseBody.articles[0].description).toBe(
+            newArticle.article.description,
+        );
+        expect(articlesResponseBody.articles[0].body).toBe(newArticle.article.body);
 
-    const deleteArticleResponse: APIResponse = await request.delete(
-      `${domain}/${articlesPath}/${articleSlugUpdated}`,
-      {
-        headers: {
-          Authorization: authToken,
-        },
-      },
-    );
-    expect(deleteArticleResponse.status()).toBe(204);
+        //DELETE
 
-    const articlesResponseAfterDelete: APIResponse = await request.get(
-      `${domain}/${articlesPath}${articlesParam}`,
-      {
-        headers: {
-          Authorization: authToken,
-        },
-      },
-    );
-    expect(articlesResponseAfterDelete.status()).toBe(200);
-    const articlesResponseBodyAfterDelete =
-      await articlesResponseAfterDelete.json();
-    expect(
-      articlesResponseBodyAfterDelete.articles.some(
-        (article: { slug: string }) => article.slug === articleSlug,
-      ),
-    ).toBeFalsy();
-  });
+        const deleteArticleResponse: APIResponse = await request.delete(
+            `${domain}/${endpoints.articles}/${articleSlug}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(deleteArticleResponse.status()).toBe(204);
+
+        const articlesResponseAfterDelete: APIResponse = await request.get(
+            `${domain}/${endpoints.articles}${articlesParam}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(articlesResponseAfterDelete.status()).toBe(httpStatus.Status200_Ok);
+        const articlesResponseBodyAfterDelete =
+            await articlesResponseAfterDelete.json();
+        expect(
+            articlesResponseBodyAfterDelete.articles.some(
+                (article: { slug: string }) => article.slug === articleSlug,
+            ),
+        ).toBeFalsy();
+    });
+    test('CREATE, UPDATE and DELETE Article', async ({ request }) => {
+
+        //CREATE ARTICLE
+        const newArticle = {
+            article: {
+                title: 'New Article Title PW AC',
+                description: 'New Article Description  PW AC',
+                body: 'This is the body of the new article.  PW AC',
+                tagList: [],
+            },
+        };
+
+        const newArticlesResponse: APIResponse = await request.post(
+            `${domain}/${endpoints.articles}`,
+            {
+                data: newArticle,
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(newArticlesResponse.status()).toBe(httpStatus.Status201_Created);
+        const newArticlesResponseBody = await newArticlesResponse.json();
+        const articleSlug = newArticlesResponseBody.article.slug;
+        expect(newArticlesResponseBody).toHaveProperty('article');
+        expect(newArticlesResponseBody.article.title).toBe(
+            newArticle.article.title,
+        );
+        expect(newArticlesResponseBody.article.description).toBe(
+            newArticle.article.description,
+        );
+        expect(newArticlesResponseBody.article.body).toBe(newArticle.article.body);
+
+        const articlesResponse: APIResponse = await request.get(
+            `${domain}/${endpoints.articles}${articlesParam}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(articlesResponse.status()).toBe(httpStatus.Status200_Ok);
+        //READ
+        const articlesResponseBody = await articlesResponse.json();
+        expect(articlesResponseBody.articles[0].title).toBe(
+            newArticle.article.title,
+        );
+        expect(articlesResponseBody.articles[0].description).toBe(
+            newArticle.article.description,
+        );
+        expect(articlesResponseBody.articles[0].body).toBe(newArticle.article.body);
+
+        //UPDATE
+        const updateArticleResponse = await request.put(
+            `${domain}/${endpoints.articles}/${articleSlug}`,
+            {
+                data: {
+                    article: {
+                        title: 'Updated Article Title PW AC',
+                        description: 'Updated Article Description PW AC',
+                        body: 'This is the updated body of the article. PW AC',
+                    },
+                },
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(updateArticleResponse.status()).toBe(httpStatus.Status200_Ok);
+        const updateArticleResponseJSON = await updateArticleResponse.json();
+        const articleSlugUpdated = updateArticleResponseJSON.article.slug;
+        expect(updateArticleResponseJSON.article.title).toBe(
+            'Updated Article Title PW AC',
+        );
+
+        //DELETE
+
+        const deleteArticleResponse: APIResponse = await request.delete(
+            `${domain}/${endpoints.articles}/${articleSlugUpdated}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(deleteArticleResponse.status()).toBe(httpStatus.Status204_No_Content);
+
+        const articlesResponseAfterDelete: APIResponse = await request.get(
+            `${domain}/${endpoints.articles}${articlesParam}`,
+            {
+                headers: {
+                    Authorization: authToken,
+                },
+            },
+        );
+        expect(articlesResponseAfterDelete.status()).toBe(httpStatus.Status200_Ok);
+        const articlesResponseBodyAfterDelete =
+            await articlesResponseAfterDelete.json();
+        expect(
+            articlesResponseBodyAfterDelete.articles.some(
+                (article: { slug: string }) => article.slug === articleSlug,
+            ),
+        ).toBeFalsy();
+    });
 });

--- a/tests/config/types/index.ts
+++ b/tests/config/types/index.ts
@@ -22,4 +22,17 @@ type ValueOf<T> = T[keyof T];
  */
 type LocaleMap = Record<string, string>;
 
-export { LocaleMap, ValueOf };
+type endpoint = {
+    tags: string;
+    login: string;
+    postArticle: string;
+    articles: string;
+    updateDeleteArticle: (slug: string) => string;
+};
+
+type httpStatusCode = {
+    Status200_Ok: number;
+    Status201_Created: number;
+    Status204_No_Content: number;
+};
+export { LocaleMap, ValueOf, endpoint, httpStatusCode };

--- a/tests/utils/constants.ts
+++ b/tests/utils/constants.ts
@@ -1,0 +1,16 @@
+import { endpoint, httpStatusCode } from '@config';
+
+export const httpStatus: httpStatusCode = {
+    Status200_Ok: 200,
+    Status201_Created: 201,
+    Status204_No_Content: 204,
+};
+
+export const endpoints: endpoint = {
+    // users: '/api/users',
+    tags: `/api/tags`,
+    login: `/api/users/login`,
+    postArticle: `/api/articles`,
+    articles: `/api/articles`,
+    updateDeleteArticle: (slug: string) => `/api/articles/${slug}`,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
       "@config": [
         "tests/config/index.ts"
       ],
-      "@logger": [
-        "tests/utils/logger.ts"
+      "@utils/*": [
+        "tests/utils/*"
       ]
     },
     "types": [


### PR DESCRIPTION
- create const to endpoints and http status code
- update playwright config to avoid tests to run twice