### PR TITLE
chore: custom expect

### DIFF
--- a/tests/api-tests/articles.spec.ts
+++ b/tests/api-tests/articles.spec.ts
@@ -32,9 +32,9 @@ test.describe(
         .path(endpoints.articles)
         .params({ limit: 10, offset: 0 })
         .getRequest(httpStatus.Status200_Ok);
-
+      expect(articlesResponse.articles.length).shouldBeLessThanOrEqual(10);
       expect(articlesResponse.articlesCount).shouldBeEqual(10)
-      expect(articlesResponse.articles.length).toBeGreaterThan(0);
+
     });
     test('CREATE and DELETE Article', async ({
       api,

--- a/tests/api-tests/articles.spec.ts
+++ b/tests/api-tests/articles.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@fixtures';
-import { expect } from '@playwright/test';
+import { expect } from '@utils/custom-expect';
 
 let authToken: string;
 
@@ -33,8 +33,8 @@ test.describe(
         .params({ limit: 10, offset: 0 })
         .getRequest(httpStatus.Status200_Ok);
 
+      expect(articlesResponse.articlesCount).shouldBeEqual(10)
       expect(articlesResponse.articles.length).toBeGreaterThan(0);
-      expect(articlesResponse.articles.length).toBeLessThanOrEqual(10);
     });
     test('CREATE and DELETE Article', async ({
       api,
@@ -59,22 +59,14 @@ test.describe(
 
       const articleSlug: string = newArticlesResponse.article.slug;
       expect(newArticlesResponse).toHaveProperty('article');
-      expect(newArticlesResponse.article.title).toBe(newArticle.article.title);
-      expect(newArticlesResponse.article.description).toBe(
-        newArticle.article.description,
-      );
-      expect(newArticlesResponse.article.body).toBe(newArticle.article.body);
+      expect(newArticlesResponse.article.title).shouldBeEqual(newArticle.article.title);
 
       const articlesResponse = await api
         .path(endpoints.articles)
         .headers({ Authorization: authToken })
         .getRequest(httpStatus.Status200_Ok);
 
-      expect(articlesResponse.articles[0].title).toBe(newArticle.article.title);
-      expect(articlesResponse.articles[0].description).toBe(
-        newArticle.article.description,
-      );
-      expect(articlesResponse.articles[0].body).toBe(newArticle.article.body);
+      expect(articlesResponse.articles[0].title).shouldBeEqual(newArticle.article.title);
 
       //DELETE
 
@@ -119,11 +111,7 @@ test.describe(
 
       const articleSlug: string = newArticlesResponse.article.slug;
       expect(newArticlesResponse).toHaveProperty('article');
-      expect(newArticlesResponse.article.title).toBe(newArticle.article.title);
-      expect(newArticlesResponse.article.description).toBe(
-        newArticle.article.description,
-      );
-      expect(newArticlesResponse.article.body).toBe(newArticle.article.body);
+      expect(newArticlesResponse.article.title).shouldBeEqual(newArticle.article.title);
 
       const articlesResponse = await api
         .path(endpoints.articles)
@@ -132,11 +120,7 @@ test.describe(
         .getRequest(httpStatus.Status200_Ok);
 
       //READ
-      expect(articlesResponse.articles[0].title).toBe(newArticle.article.title);
-      expect(articlesResponse.articles[0].description).toBe(
-        newArticle.article.description,
-      );
-      expect(articlesResponse.articles[0].body).toBe(newArticle.article.body);
+      expect(articlesResponse.articles[0].title).shouldBeEqual(newArticle.article.title);
 
       //UPDATE
       const updateArticleResponse = await api
@@ -152,7 +136,7 @@ test.describe(
         .putRequest(httpStatus.Status200_Ok);
 
       const articleSlugUpdated: string = updateArticleResponse.article.slug;
-      expect(updateArticleResponse.article.title).toBe(
+      expect(updateArticleResponse.article.title).shouldBeEqual(
         'Updated Article Title PW AC',
       );
 

--- a/tests/api-tests/tags.spec.ts
+++ b/tests/api-tests/tags.spec.ts
@@ -11,13 +11,14 @@ test.describe(
     tag: ['@tags'],
   },
   () => {
-    test('GET tags', async ({ api, endpoints, httpStatus }) => {
+    test('GET tags', async ({ api, endpoints, httpStatus: { Status200_Ok } }) => {
       const tagsResponse = await api
         .path(endpoints.tags)
-        .getRequest(httpStatus.Status200_Ok);
+        .getRequest(Status200_Ok);
       expect(tagsResponse).toHaveProperty('tags');
-      expect(tagsResponse.tags.length).toBeGreaterThan(0);
-      expect(tagsResponse.tags.length).shouldBeEqual(10);
+      expect(tagsResponse.tags[0]).shouldBeEqual('Test');
+      expect(tagsResponse.tags.length).shouldBeLessThanOrEqual(10);
+
     });
   },
 );

--- a/tests/api-tests/tags.spec.ts
+++ b/tests/api-tests/tags.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@fixtures';
-import { expect } from '@playwright/test';
+import { expect } from '@utils/custom-expect';
 
 test.describe(
   'Feature: Tags API',
@@ -17,7 +17,7 @@ test.describe(
         .getRequest(httpStatus.Status200_Ok);
       expect(tagsResponse).toHaveProperty('tags');
       expect(tagsResponse.tags.length).toBeGreaterThan(0);
-      expect(tagsResponse.tags.length).toBeLessThanOrEqual(10);
+      expect(tagsResponse.tags.length).shouldBeEqual(10);
     });
   },
 );

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -2,6 +2,7 @@ import * as Config from '@config';
 import { Homepage } from '@pages/Homepage';
 import { test as base } from '@playwright/test';
 import { endpoints, httpStatus } from '@utils/constants';
+import { setCustomExpectLogger } from '@utils/custom-expect';
 import { APILogger } from '@utils/logger';
 import { RequestHandler } from '@utils/request-handler';
 
@@ -14,7 +15,7 @@ export const test = base.extend<{
 }>({
   api: async ({ request }, use) => {
     const logger = new APILogger();
-    // setCustomExpectLogger(logger);
+    setCustomExpectLogger(logger);
     const requestHandler = new RequestHandler(
       request,
       'https://conduit-api.bondaracademy.com/', // config.apiUrl as string,
@@ -28,7 +29,7 @@ export const test = base.extend<{
     await use(homepage);
   },
   // eslint-disable-next-line no-empty-pattern
-  config: async ({}, use) => {
+  config: async ({ }, use) => {
     const config = Config;
     await use(config);
   },

--- a/tests/utils/custom-expect.ts
+++ b/tests/utils/custom-expect.ts
@@ -1,0 +1,47 @@
+import { expect as baseExpect } from '@playwright/test';
+import { APILogger } from './logger';
+
+let apiLogger: APILogger;
+
+export const setCustomExpectLogger = (logger: APILogger) => {
+    apiLogger = logger;
+}
+declare global {
+    namespace PlaywrightTest {
+        interface Matchers<R, T> {
+            shouldBeEqual(expected: T): R;
+        }
+    }
+}
+export const expect = baseExpect.extend({
+    shouldBeEqual(received: any, expected: any) {
+        let pass: boolean;
+        let logs: string = '';
+        try {
+            baseExpect(received).toEqual(expected);
+            pass = true;
+            if (this.isNot) {
+                logs = apiLogger
+                    ? apiLogger.getRecentLogs()
+                    : 'No API logs available';
+            }
+        } catch (e: any) {
+            pass = false;
+            logs = apiLogger
+                ? apiLogger.getRecentLogs()
+                : 'No API logs available';
+        }
+        const hint = this.isNot ? 'not ' : '';
+
+        const message =
+            this.utils.matcherHint('shouldBeEqual', undefined, undefined, {
+                isNot: this.isNot,
+            }) +
+            '\n\n' +
+            `Expected: ${hint}${this.utils.printExpected(expected)}\n` +
+            `Received: ${this.utils.printReceived(received)}\n\n` +
+            `Recent API Activity: \n${logs}`;
+        return { message: () => message, pass };
+    }
+
+})

--- a/tests/utils/custom-expect.ts
+++ b/tests/utils/custom-expect.ts
@@ -10,6 +10,7 @@ declare global {
     namespace PlaywrightTest {
         interface Matchers<R, T> {
             shouldBeEqual(expected: T): R;
+            shouldBeLessThanOrEqual(expected: T): R;
         }
     }
 }
@@ -42,6 +43,36 @@ export const expect = baseExpect.extend({
             `Received: ${this.utils.printReceived(received)}\n\n` +
             `Recent API Activity: \n${logs}`;
         return { message: () => message, pass };
-    }
+    },
+    shouldBeLessThanOrEqual(received: any, expected: any) {
+        let pass: boolean;
+        let logs: string = '';
+        try {
+            baseExpect(received).toBeLessThanOrEqual(expected);
+            pass = true;
+            if (this.isNot) {
+                logs = apiLogger.getRecentLogs();
+            }
+        } catch (e: any) {
+            pass = false;
+            logs = apiLogger.getRecentLogs();
+        }
+        const hint = this.isNot ? 'not ' : '';
+
+        const message =
+            this.utils.matcherHint(
+                'shouldBeLessThanOrEqual',
+                undefined,
+                undefined,
+                {
+                    isNot: this.isNot,
+                }
+            ) +
+            '\n\n' +
+            `Expected: ${hint}${this.utils.printExpected(expected)}\n` +
+            `Received: ${this.utils.printReceived(received)}\n\n` +
+            `Recent API Activity: \n${logs}`;
+        return { message: () => message, pass };
+    },
 
 })

--- a/tests/utils/logger.ts
+++ b/tests/utils/logger.ts
@@ -6,7 +6,13 @@ export class APILogger {
     headers: Record<string, string>,
     body?: any,
   ) {
-    const logEntry = { method, url, headers, body };
+    // Deep clone the body to avoid mutating the original
+    const safeBody = body ? JSON.parse(JSON.stringify(body)) : undefined;
+    if (safeBody?.user?.password) {
+      safeBody.user.password = '***';
+    }
+
+    const logEntry = { method, url, headers, body: safeBody };
     this.recentLogs.push({ type: 'Response Details', data: logEntry });
   }
   logResponse(statusCode: number, body?: any) {


### PR DESCRIPTION



add setCustomExpectLogged method and pass the instance logger inside
inside the method, we extended the base expect with a new capabilities, `shouldBeEqual `and `shouldBeLessThanOrEqual `in order to have the custom message printed in case of failure + existing message